### PR TITLE
Move existing schemas to new `schemas.py` file

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,39 @@ class TestEchoGet:
 ```
 
 </details>
+
+## Step 2
+
+<details>
+    <summary>Create some endpoints the receive and send known schemas.</summary>
+    <br>
+    The following are the commands I used:
+
+Create a new file called `schemas.py` in the `mentoring_fastapi` folder and move the `EchoResponse` schema there.
+
+This file should look like the following:
+
+```python
+import pydantic
+
+
+class EchoResponse(pydantic.BaseModel):
+    greeting: str
+```
+
+Update the echo GET endpoint to use the schema from the new file and clean up the `main.py` file so it looks like the following.
+
+```python
+from fastapi import FastAPI
+
+from mentoring_fastapi import schemas
+
+app = FastAPI()
+
+
+@app.get("/echo/{name}")
+async def echo(name: str) -> schemas.EchoResponse:
+    return schemas.EchoResponse(greeting=f"Hello {name}!")
+```
+
+</details>

--- a/src/mentoring_fastapi/main.py
+++ b/src/mentoring_fastapi/main.py
@@ -1,13 +1,10 @@
 from fastapi import FastAPI
-import pydantic
+
+from mentoring_fastapi import schemas
 
 app = FastAPI()
 
 
-class EchoResponse(pydantic.BaseModel):
-    greeting: str
-
-
 @app.get("/echo/{name}")
-async def echo(name: str) -> EchoResponse:
-    return EchoResponse(greeting=f"Hello {name}!")
+async def echo(name: str) -> schemas.EchoResponse:
+    return schemas.EchoResponse(greeting=f"Hello {name}!")

--- a/src/mentoring_fastapi/schemas.py
+++ b/src/mentoring_fastapi/schemas.py
@@ -1,0 +1,5 @@
+import pydantic
+
+
+class EchoResponse(pydantic.BaseModel):
+    greeting: str


### PR DESCRIPTION
Prior to this change, the response schema for the echo GET endpoint was defined inline in the `main.py` file.

This change moves that schema out into its own `schemas.py` file.