### PR TITLE
Update the `EchoResponse` model to use new base model

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,4 +109,30 @@ async def echo(name: str) -> schemas.EchoResponse:
     return schemas.EchoResponse(greeting=f"Hello {name}!")
 ```
 
+Update the schemas to add a new base model which enables the `from_attributes` setting.
+
+The `schemas.py` file should now look like this:
+
+```python
+import typing
+
+import pydantic
+
+
+class OrmBaseModel(pydantic.BaseModel):
+    """
+    Base model for ORM objects to enable ORM mode.
+
+    NOTE: ORM mode has been renamed to `from_attributes` in Pydantic v2.
+    """
+
+    model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(
+        from_attributes=True,
+    )
+
+
+class EchoResponse(OrmBaseModel):
+    greeting: str
+```
+
 </details>

--- a/src/mentoring_fastapi/schemas.py
+++ b/src/mentoring_fastapi/schemas.py
@@ -1,5 +1,20 @@
+import datetime
+import typing
+
 import pydantic
 
 
-class EchoResponse(pydantic.BaseModel):
+class OrmBaseModel(pydantic.BaseModel):
+    """
+    Base model for ORM objects to enable ORM mode.
+
+    NOTE: ORM mode has been renamed to `from_attributes` in Pydantic v2.
+    """
+
+    model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(
+        from_attributes=True,
+    )
+
+
+class EchoResponse(OrmBaseModel):
     greeting: str


### PR DESCRIPTION
Prior to this change, there was no common base model to enable configurations of all schemas across the application.

This change adds a new base class and swaps the `EchoResponse` schema to instead use this base model rather than directly inherit from the pydantic base model.